### PR TITLE
Change column number for right alignment

### DIFF
--- a/lib/fukuzatsu/formatters/text.rb
+++ b/lib/fukuzatsu/formatters/text.rb
@@ -33,7 +33,7 @@ module Fukuzatsu
           headings: header,
           rows: rows,
         )
-        table.align_column(3, :right)
+        table.align_column(2, :right)
         puts table
       end
 

--- a/spec/formatters/text_spec.rb
+++ b/spec/formatters/text_spec.rb
@@ -35,4 +35,13 @@ describe Fukuzatsu::Formatters::Text do
     end
   end
 
+  describe "#export" do
+    it "'puts' a table" do
+      class_source = File.open("./spec/fixtures/class.rb", "r").readlines
+      summary = Fukuzatsu::Summary.from(content: class_source.join("\n")).first
+
+      text_formatter = Fukuzatsu::Formatters::Text.new(summary: summary, base_output_path: nil)
+      expect(text_formatter.export).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
First, thanks for this project! I'm very interested in code complexity. I had the same issue with the text formatter and after poking around a little bit I think I found the problem. `Terminal::Table#align_column` starts at column 0, so with a 3 column format, the right column is column 2.

The test isn't great, but it should catch a regression. fixes #5  